### PR TITLE
feat: NewRelicのAPM (nrmysql)を導入 + 詳細のクエリが出せるように対応

### DIFF
--- a/isucon13/go/go.sum
+++ b/isucon13/go/go.sum
@@ -11,6 +11,7 @@ github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.3.1 h1:KjJaJ9iWZ3jOFZIf1Lqf4laDRCasjl0BCmnEGxkdLb4=
 github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/context v1.1.1 h1:AWwleXJkX/nhcU9bZSnZoi3h/qGYqQAGhq6zZe/aQW8=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=

--- a/isucon13/go/main.go
+++ b/isucon13/go/main.go
@@ -130,7 +130,7 @@ func main() {
 	// newrelic APM
 	var app *newrelic.Application
 	var err error
-	app, err = newrelic.NewApplication(
+	newrelic.NewApplication(
 		newrelic.ConfigAppName(os.Getenv("NEW_RELIC_APP_NAME")),
 		newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
 		newrelic.ConfigAppLogEnabled(false),
@@ -139,6 +139,11 @@ func main() {
 			config.DatastoreTracer.RawQuery.Enabled = true
 		},
 	)
+	if err != nil {
+		fmt.Errorf("failed to init newrelic NewApplication reason: %v", err)
+	} else {
+		fmt.Println("newrelic init success")
+	}
 
 	e.Use(middleware.Logger())
 	cookieStore := sessions.NewCookieStore(secret)

--- a/isucon13/go/main.go
+++ b/isucon13/go/main.go
@@ -134,6 +134,10 @@ func main() {
 		newrelic.ConfigAppName(os.Getenv("NEW_RELIC_APP_NAME")),
 		newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
 		newrelic.ConfigAppLogEnabled(false),
+		newrelic.ConfigAppLogEnabled(false),
+		func(config *newrelic.Config) {
+			config.DatastoreTracer.RawQuery.Enabled = true
+		},
 	)
 
 	e.Use(middleware.Logger())


### PR DESCRIPTION
NRUGでのヒント

```
デフォルトだとそうなるようですね。
ざっくり追いかけてみましたが、設定で[raw queryのロギングもできそう](https://github.com/newrelic/go-agent/blob/master/v3/newrelic/internal_txn.go#L940-L942)です。
ただし、表向きに書かれてない設定値のようですね
...Traceに個人情報が載ったり、Traceの容量が肥大化したりする懸念からかな？
( newrelic.Config に[設定して渡す感じ](https://docs.newrelic.com/jp/docs/apm/agents/go-agent/configuration/go-agent-configuration/#datastore-tracer)っぽい）
segment.RawQuery は[ここで](https://github.com/newrelic/go-agent/blob/master/v3/newrelic/sqlparse/sqlparse.go#L57-L71)取得。コメント抜いた生クエリですね。
フラグ立ってない時にセットされるParameterizedQueryは[ここ](https://github.com/newrelic/go-agent/blob/82c8f8440ca84eb68e08248d877fa1d0b55da333/v3/newrelic/tracing.go#L776-L783)かな。
```

```
そのドキュメントに記載されてないんですよね。実装上は存在するので、
app, err = newrelic.NewApplication(
	newrelic.ConfigAppName(os.Getenv("NEW_RELIC_APP_NAME")),
	newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
	newrelic.ConfigAppLogEnabled(false),
	func(config *newrelic.Config) {
		config.DatastoreTracer.RawQuery.Enabled = true
	},
)
な感じでいけると思いますが...
```